### PR TITLE
fix: define flagKeyRef constant to eliminate duplicated "key-ref" literal (SonarQube #3)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -114,7 +114,7 @@ func init() {
 	addCmd.Flags().StringVar(&sshUser, "user", "root", "SSH user")
 	addCmd.Flags().IntVar(&port, "port", 22, "SSH port")
 	addCmd.Flags().StringVar(&key, "key", "~/.ssh/id_rsa", "SSH key")
-	addCmd.Flags().StringVar(&keyRef, "key-ref", "", "Reference to encrypted key stored in repo")
+	addCmd.Flags().StringVar(&keyRef, flagKeyRef, "", "Reference to encrypted key stored in repo")
 	addCmd.Flags().StringVar(&password, "password", "", "SSH password")
 
 	addCmd.MarkFlagRequired("host")

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,0 +1,6 @@
+package cmd
+
+// Flag name constants shared across commands.
+const (
+	flagKeyRef = "key-ref"
+)

--- a/cmd/constants_test.go
+++ b/cmd/constants_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestFlagKeyRefConstant(t *testing.T) {
+	if flagKeyRef != "key-ref" {
+		t.Errorf("flagKeyRef = %q, want %q", flagKeyRef, "key-ref")
+	}
+}
+
+func TestEditCmdHasKeyRefFlag(t *testing.T) {
+	f := editCmd.Flags().Lookup(flagKeyRef)
+	if f == nil {
+		t.Errorf("editCmd does not have flag %q", flagKeyRef)
+	}
+}
+
+func TestAddCmdHasKeyRefFlag(t *testing.T) {
+	f := addCmd.Flags().Lookup(flagKeyRef)
+	if f == nil {
+		t.Errorf("addCmd does not have flag %q", flagKeyRef)
+	}
+}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -43,12 +43,12 @@ var editCmd = &cobra.Command{
 			return
 		}
 
-		if clearKeyRef && cmd.Flags().Changed("key-ref") {
+		if clearKeyRef && cmd.Flags().Changed(flagKeyRef) {
 			fmt.Println("Error: --clear-key-ref cannot be used with --key-ref")
 			return
 		}
 
-		if cmd.Flags().Changed("key") && cmd.Flags().Changed("key-ref") {
+		if cmd.Flags().Changed("key") && cmd.Flags().Changed(flagKeyRef) {
 			fmt.Println("Error: --key and --key-ref cannot be used together")
 			return
 		}
@@ -69,7 +69,7 @@ var editCmd = &cobra.Command{
 			s.Key = editKey
 		}
 
-		if cmd.Flags().Changed("key-ref") {
+		if cmd.Flags().Changed(flagKeyRef) {
 			s.KeyRef = editKeyRef
 			s.Key = ""
 		}
@@ -119,7 +119,7 @@ var editCmd = &cobra.Command{
 			s.KeyRef = ""
 		}
 
-		if s.Password != "" && (cmd.Flags().Changed("key") || cmd.Flags().Changed("key-ref")) && !cmd.Flags().Changed("password") && !clearPassword {
+		if s.Password != "" && (cmd.Flags().Changed("key") || cmd.Flags().Changed(flagKeyRef)) && !cmd.Flags().Changed("password") && !clearPassword {
 			fmt.Println("Warning: server has a stored password; key will be ignored unless password is cleared.")
 		}
 
@@ -149,7 +149,7 @@ func init() {
 	editCmd.Flags().StringVar(&editUser, "user", "", "SSH user")
 	editCmd.Flags().IntVar(&editPort, "port", 0, "SSH port")
 	editCmd.Flags().StringVar(&editKey, "key", "", "SSH key")
-	editCmd.Flags().StringVar(&editKeyRef, "key-ref", "", "Reference to encrypted key stored in repo")
+	editCmd.Flags().StringVar(&editKeyRef, flagKeyRef, "", "Reference to encrypted key stored in repo")
 	editCmd.Flags().StringVar(&editPassword, "password", "", "SSH password")
 	editCmd.Flags().BoolVar(&clearPassword, "clear-password", false, "Clear stored password")
 	editCmd.Flags().BoolVar(&clearKeyRef, "clear-key-ref", false, "Clear stored key reference")


### PR DESCRIPTION
## Summary

Fixes SonarQube issue **AZz2TH23EC5WbycKyjwP** (CRITICAL): the string literal `"key-ref"` was duplicated 5 times in `cmd/edit.go` and once more in `cmd/add.go`.

Closes #3

## Changes

- **`cmd/constants.go`** (new): declares a package-level constant `flagKeyRef = "key-ref"` shared across the `cmd` package.
- **`cmd/edit.go`**: replaces all 5 occurrences of the `"key-ref"` literal with `flagKeyRef`.
- **`cmd/add.go`**: replaces the 1 occurrence of the `"key-ref"` literal in flag registration with `flagKeyRef`.
- **`cmd/constants_test.go`** (new): adds tests to verify the constant value and that both `editCmd` and `addCmd` register the flag under the correct name.

## Testing

All existing tests continue to pass, and 3 new tests cover the constant and flag registration.

_This PR was generated with [Oz](https://www.warp.dev/oz)._
