### PR TITLE
refactor(server): define constant for repeated "1.2.3.4" literal (fixes #2)

### DIFF
--- a/internal/server/validate_test.go
+++ b/internal/server/validate_test.go
@@ -2,10 +2,12 @@ package server
 
 import "testing"
 
+const testHost = "1.2.3.4"
+
 func TestValidateAndRepairDefaults(t *testing.T) {
 	input := Server{
 		Name: "prod",
-		Host: "1.2.3.4",
+		Host: testHost,
 	}
 
 	out, err := ValidateAndRepair(input)
@@ -29,7 +31,7 @@ func TestValidateAndRepairDefaults(t *testing.T) {
 func TestValidateAndRepairInvalidPort(t *testing.T) {
 	input := Server{
 		Name: "prod",
-		Host: "1.2.3.4",
+		Host: testHost,
 		Port: 70000,
 	}
 
@@ -42,7 +44,7 @@ func TestValidateAndRepairInvalidPort(t *testing.T) {
 func TestValidateAndRepairAuthPrecedence(t *testing.T) {
 	input := Server{
 		Name:     "prod",
-		Host:     "1.2.3.4",
+		Host:     testHost,
 		User:     "ubuntu",
 		Port:     22,
 		Key:      "~/.ssh/id_rsa",


### PR DESCRIPTION
## Summary

Fixes #2 — SonarQube flagged the string literal `"1.2.3.4"` as duplicated three times in `internal/server/validate_test.go` (critical severity, issue key `AZz2TH5OEC5WbycKyjwT`).

## Change

Introduced a single package-level constant `testHost = "1.2.3.4"` in the test file and replaced all three occurrences of the inline literal with it. No production code was changed; all existing tests continue to pass.

_This PR was generated with [Oz](https://www.warp.dev/oz)._
