### PR TITLE
fix: group consecutive same-type parameters (SonarQube #6)

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -120,7 +120,7 @@ func init() {
 	rootCmd.AddCommand(authCmd)
 }
 
-func setupTOTP(repoDir string, email string, reader *bufio.Reader) error {
+func setupTOTP(repoDir, email string, reader *bufio.Reader) error {
 
 	secret, err := totp.GenerateSecret()
 	if err != nil {

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -19,7 +19,7 @@ const (
 
 // Encrypt encrypts plaintext using AES-256-GCM with a key derived from passphrase via scrypt.
 // Returns a base64-encoded string containing: salt + nonce + ciphertext.
-func Encrypt(plaintext string, passphrase string) (string, error) {
+func Encrypt(plaintext, passphrase string) (string, error) {
 
 	salt := make([]byte, saltSize)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
@@ -58,7 +58,7 @@ func Encrypt(plaintext string, passphrase string) (string, error) {
 }
 
 // Decrypt decrypts a base64-encoded string produced by Encrypt.
-func Decrypt(encoded string, passphrase string) (string, error) {
+func Decrypt(encoded, passphrase string) (string, error) {
 
 	combined, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CloneRepo clones the git repository if it does not already exist
-func CloneRepo(repoURL string, path string) error {
+func CloneRepo(repoURL, path string) error {
 
 	// Check if repo already exists
 	if _, err := os.Stat(path); err == nil {
@@ -36,7 +36,7 @@ func CloneRepo(repoURL string, path string) error {
 }
 
 // CommitAndPush stages all changes, commits them, and pushes to remote
-func CommitAndPush(repoPath string, message string) error {
+func CommitAndPush(repoPath, message string) error {
 
 	repo, err := git.PlainOpen(repoPath)
 	if err != nil {

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -16,7 +16,7 @@ type UsersFile struct {
 	Users []interface{} `json:"users"`
 }
 
-func CloneOrInitRepo(repoURL string, repoDir string) error {
+func CloneOrInitRepo(repoURL, repoDir string) error {
 
 	// try cloning
 	_, err := gogit.PlainClone(repoDir, false, &gogit.CloneOptions{

--- a/internal/server/loader.go
+++ b/internal/server/loader.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func LoadServer(repoDir string, name string) (*Server, error) {
+func LoadServer(repoDir, name string) (*Server, error) {
 
 	serverDir := filepath.Join(repoDir, "servers")
 	candidates := []string{
@@ -89,7 +89,7 @@ func LoadServers(repoDir string) ([]Server, error) {
 	return servers, nil
 }
 
-func RemoveServer(repoDir string, name string) error {
+func RemoveServer(repoDir, name string) error {
 
 	serverDir := filepath.Join(repoDir, "servers")
 	candidates := []string{

--- a/internal/totp/store.go
+++ b/internal/totp/store.go
@@ -15,18 +15,18 @@ type SecretFile struct {
 	Data    string `yaml:"data"`
 }
 
-func SecretPath(repoDir string, email string) string {
+func SecretPath(repoDir, email string) string {
 
 	dir := filepath.Join(repoDir, "totp")
 	return filepath.Join(dir, sanitize(email)+".yaml")
 }
 
-func HasSecret(repoDir string, email string) bool {
+func HasSecret(repoDir, email string) bool {
 	_, err := os.Stat(SecretPath(repoDir, email))
 	return err == nil
 }
 
-func SaveEncryptedSecret(repoDir string, email string, encrypted string) error {
+func SaveEncryptedSecret(repoDir, email, encrypted string) error {
 
 	dir := filepath.Join(repoDir, "totp")
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -46,7 +46,7 @@ func SaveEncryptedSecret(repoDir string, email string, encrypted string) error {
 	return os.WriteFile(SecretPath(repoDir, email), data, 0644)
 }
 
-func LoadEncryptedSecret(repoDir string, email string) (string, error) {
+func LoadEncryptedSecret(repoDir, email string) (string, error) {
 
 	path := SecretPath(repoDir, email)
 	data, err := os.ReadFile(path)

--- a/internal/totp/totp.go
+++ b/internal/totp/totp.go
@@ -28,7 +28,7 @@ func GenerateSecret() (string, error) {
 	return enc.EncodeToString(secret), nil
 }
 
-func OTPAuthURL(issuer string, account string, secret string) string {
+func OTPAuthURL(issuer, account, secret string) string {
 
 	label := fmt.Sprintf("%s:%s", issuer, account)
 
@@ -42,7 +42,7 @@ func OTPAuthURL(issuer string, account string, secret string) string {
 	return "otpauth://totp/" + url.PathEscape(label) + "?" + v.Encode()
 }
 
-func Validate(secret string, code string, now time.Time) bool {
+func Validate(secret, code string, now time.Time) bool {
 
 	code = strings.ReplaceAll(strings.TrimSpace(code), " ", "")
 	if len(code) != defaultDigits {

--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -44,7 +44,7 @@ func UserExists(users *UsersFile, email string) bool {
 	return false
 }
 
-func AddUser(users *UsersFile, username string, email string) {
+func AddUser(users *UsersFile, username, email string) {
 
 	users.Users = append(users.Users, User{
 		Username: username,


### PR DESCRIPTION
## Summary

Resolves SonarQube issue **AZz2TH54EC5WbycKyjwh** — _"Group together these consecutive parameters of the same type"_ (originally flagged in `internal/keys/keys.go` line 39).

Closes #6

## What changed

Applied Go's idiomatic grouped parameter syntax (`a, b string` instead of `a string, b string`) to all functions in the codebase that had consecutive parameters of the same type:

| Package | Functions updated |
|---|---|
| `internal/crypto` | `Encrypt`, `Decrypt` |
| `internal/git` | `CloneRepo`, `CommitAndPush`, `CloneOrInitRepo` |
| `internal/user` | `AddUser` |
| `internal/server` | `LoadServer`, `RemoveServer` |
| `internal/totp` | `OTPAuthURL`, `Validate`, `SecretPath`, `HasSecret`, `SaveEncryptedSecret`, `LoadEncryptedSecret` |
| `cmd` | `setupTOTP` |

These are purely syntactic changes — no logic or behaviour is modified.

## Testing

All existing tests pass (`go test ./...`). No new tests are required since this is a refactor with no behavioural change.

_This PR was generated with [Oz](https://www.warp.dev/oz)._
