### PR TITLE
fix: group parameters by purpose in EncryptKeyFile

### DIFF
--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -21,7 +21,7 @@ func KeyPath(repoDir, name string) string {
 	return filepath.Join(repoDir, "keys", name+".yaml")
 }
 
-func EncryptKeyFile(repoDir, name, filePath, passphrase string) error {
+func EncryptKeyFile(repoDir, name string, filePath, passphrase string) error {
 
 	raw, err := os.ReadFile(filePath)
 	if err != nil {


### PR DESCRIPTION
SonarQube (AZz2TH54EC5WbycKyjwg) flagged consecutive parameters of the same type not being grouped by logical purpose in keys.go.

Grouped parameters in EncryptKeyFile by their semantic purpose:
- repoDir, name: key location parameters
- filePath, passphrase: encryption operation parameters

This improves code readability over grouping all strings together.

Fixes #5