### PR TITLE
fix: group consecutive parameters of the same type in keys.go

### DIFF
--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -17,11 +17,11 @@ type KeyFile struct {
 	Data    string `yaml:"data"`
 }
 
-func KeyPath(repoDir string, name string) string {
+func KeyPath(repoDir, name string) string {
 	return filepath.Join(repoDir, "keys", name+".yaml")
 }
 
-func EncryptKeyFile(repoDir string, name string, filePath string, passphrase string) error {
+func EncryptKeyFile(repoDir, name, filePath, passphrase string) error {
 
 	raw, err := os.ReadFile(filePath)
 	if err != nil {
@@ -36,7 +36,7 @@ func EncryptKeyFile(repoDir string, name string, filePath string, passphrase str
 	return SaveEncryptedKey(repoDir, name, encrypted)
 }
 
-func SaveEncryptedKey(repoDir string, name string, encrypted string) error {
+func SaveEncryptedKey(repoDir, name, encrypted string) error {
 
 	dir := filepath.Join(repoDir, "keys")
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -56,7 +56,7 @@ func SaveEncryptedKey(repoDir string, name string, encrypted string) error {
 	return os.WriteFile(KeyPath(repoDir, name), data, 0644)
 }
 
-func LoadEncryptedKey(repoDir string, name string) (string, error) {
+func LoadEncryptedKey(repoDir, name string) (string, error) {
 
 	data, err := os.ReadFile(KeyPath(repoDir, name))
 	if err != nil {
@@ -75,7 +75,7 @@ func LoadEncryptedKey(repoDir string, name string) (string, error) {
 	return f.Data, nil
 }
 
-func DecryptKey(repoDir string, name string, passphrase string) ([]byte, error) {
+func DecryptKey(repoDir, name, passphrase string) ([]byte, error) {
 
 	encrypted, err := LoadEncryptedKey(repoDir, name)
 	if err != nil {
@@ -118,7 +118,7 @@ func ListKeys(repoDir string) ([]string, error) {
 	return names, nil
 }
 
-func RemoveKey(repoDir string, name string) error {
+func RemoveKey(repoDir, name string) error {
 	return os.Remove(KeyPath(repoDir, name))
 }
 


### PR DESCRIPTION
**Summary of changes:**
- Fixed SonarQube issue AZz2TH54EC5WbycKyjwi in `internal/keys/keys.go`
- Grouped consecutive `string` parameters in 6 function signatures (e.g., `repoDir string, name string` → `repoDir, name string`)